### PR TITLE
Support for functions returning Future

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ class Example extends Instrumented {
   def writeData(obj:MyClass) {
     db.write(obj)
   }
+  
+  @Timed("writeAsync")
+  def writeDataAsync(obj:MyClass):Future[Boolean]= {
+    db.asyncWrite(obj)
+  }
 
 }
 ```
@@ -50,7 +55,7 @@ class Example extends Instrumented {
 SBT:
 ```
 resolvers += Resolver.jcenterRepo
-libraryDependencies += "com.flipkart" %% "espion" % "1.0.3"
+libraryDependencies += "com.flipkart" %% "espion" % "1.0.4"
 ```
 
 Then following in build.sbt
@@ -67,7 +72,7 @@ Maven:
 <dependency>
     <groupId>com.flipkart</groupId>
     <artifactId>espion_${scala.dep.version}</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 </dependency>
 <repositories>
   <repository>
@@ -81,8 +86,6 @@ Maven:
 </repositories>
 <!-- You will also need to add this compiler plugin http://docs.scala-lang.org/overviews/macros/paradise.html -->
 ```
-
-
 
 
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ object Utils extends Build {
   val branch = Process("git" :: "rev-parse" :: "--abbrev-ref" :: "HEAD" :: Nil).!!.trim
   val suffix = if (branch == "master") "" else "-SNAPSHOT"
 
-  val libVersion = "1.0.3" + suffix
+  val libVersion = "1.0.4" + suffix
 
 
   def scalacOptionsVersion(sv: String): Seq[String] = {


### PR DESCRIPTION
Adds support for functions returning `Future[_]`. The metric will calculate absolute time which would be from start of function call to the future being completed.